### PR TITLE
Replace chunky_png with rmagick for cropping the image

### DIFF
--- a/dotdiff.gemspec
+++ b/dotdiff.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "chunky_png", '~> 1.3'
+  spec.add_runtime_dependency "rmagick", '~> 2.15'
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/dotdiff/image/cropper.rb
+++ b/lib/dotdiff/image/cropper.rb
@@ -1,11 +1,10 @@
-require 'chunky_png'
+require 'rmagick'
 
 module DotDiff
   module Image
     module Cropper
       def crop_and_resave(element)
         image = load_image(fullscreen_file)
-
         image.crop!(
           element.rectangle.x,
           element.rectangle.y,
@@ -13,11 +12,11 @@ module DotDiff
           height(element, image)
         )
 
-        image.save(cropped_file)
+        image.write(cropped_file)
       end
 
-      def load_image(image_file)
-        ::ChunkyPNG::Image.from_file(image_file)
+      def load_image(file)
+        Magick::Image.read(file).first
       end
 
       def height(element, image)

--- a/spec/unit/image/cropper_spec.rb
+++ b/spec/unit/image/cropper_spec.rb
@@ -12,9 +12,9 @@ class Snappy
   end
 end
 
-class MockChunkyPNG
+class MockRMagick
   def crop!(x,y,w,h); end
-  def save(file);  end
+  def write(file);  end
   def width; end
   def height; end
 end
@@ -23,11 +23,11 @@ RSpec.describe DotDiff::Image::Cropper do
   subject { Snappy.new }
 
   let(:element) { DotDiff::ElementMeta.new(MockPage.new, MockElement.new) }
-  let(:mock_png) { MockChunkyPNG.new }
+  let(:mock_png) { MockRMagick.new }
 
   describe '#load_image' do
     it 'calls chunky_png image from file' do
-      expect(ChunkyPNG::Image).to receive(:from_file).with('/home/se/full.png').once
+      expect(Magick::Image).to receive(:read).with('/home/se/full.png').once.and_return([])
       subject.send(:load_image, '/home/se/full.png')
     end
   end
@@ -48,7 +48,7 @@ RSpec.describe DotDiff::Image::Cropper do
       expect(subject).to receive(:height).with(element, mock_png).and_return(14).once
 
       expect(mock_png).to receive(:crop!).with(1,2,13,14).once
-      expect(mock_png).to receive(:save).with('/tmp/T/cropped.png').once
+      expect(mock_png).to receive(:write).with('/tmp/T/cropped.png').once
 
       subject.crop_and_resave(element)
     end


### PR DESCRIPTION
Chunky png isn't efficient enough for our use case and is a large memory overhead and slower than imagemagick. by as much as ~15seconds for 5 image crops from the browser viewport (1280x1029). Sorry chunky_png :(