### PR TITLE
Create a failure_path/file method on snapshot for usage elsewhere

### DIFF
--- a/lib/dotdiff/comparer.rb
+++ b/lib/dotdiff/comparer.rb
@@ -48,10 +48,8 @@ module DotDiff
       result.run(snapshot.basefile, compare_to_image)
 
       if result.failed? && DotDiff.failure_image_path
-        failure_path = File.join(DotDiff.failure_image_path, snapshot.subdir)
-
-        FileUtils.mkdir_p(failure_path)
-        FileUtils.mv(compare_to_image, File.join(failure_path, snapshot.base_filename), force: true)
+        FileUtils.mkdir_p(snapshot.failure_path)
+        FileUtils.mv(compare_to_image, snapshot.failure_file, force: true)
       end
 
       [result.passed?, result.message]

--- a/lib/dotdiff/snapshot.rb
+++ b/lib/dotdiff/snapshot.rb
@@ -40,6 +40,14 @@ module DotDiff
       rtn_file
     end
 
+    def failure_path
+      File.join(DotDiff.failure_image_path, subdir)
+    end
+
+    def failure_file
+      File.join(failure_path, "#{base_filename(false)}.diff" )
+    end
+
     def capture_from_browser(hide_and_show = true, element_handler = ElementHandler.new(page))
       if hide_and_show
         element_handler.hide

--- a/spec/unit/comparer_spec.rb
+++ b/spec/unit/comparer_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe DotDiff::Comparer do
 
           expect(FileUtils).to receive(:mkdir_p).with('/tmp/fails/images').once
           expect(FileUtils).to receive(:mv)
-            .with('/tmp/new.png', '/tmp/fails/images/test.png', force: true)
+            .with('/tmp/new.png', '/tmp/fails/images/test.diff', force: true)
 
           expect(subject.send(:compare, '/tmp/new.png')).to eq(
             [false, 'FAILED: 120px pixel different']

--- a/spec/unit/snapshot_spec.rb
+++ b/spec/unit/snapshot_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe DotDiff::Snapshot do
 
   before do
     allow(Dir).to receive(:tmpdir).and_return('/tmp/T')
+    allow(DotDiff).to receive(:failure_image_path).and_return("/tmp/failures")
     allow(DotDiff).to receive(:image_store_path).and_return('/home/se/images')
   end
 
@@ -42,6 +43,18 @@ RSpec.describe DotDiff::Snapshot do
 
     it 'returns the name without the extension' do
       expect(subject.base_filename(false)).to eq 'CancellationDialog'
+    end
+  end
+
+  describe '#failure_path' do
+    it 'returns dotdiff and subdir joined' do
+      expect(subject.failure_path).to eq '/tmp/failures/testy'
+    end
+  end
+
+  describe '#failure_file' do
+    it 'returns the failure_path and filename with diff extension' do
+      expect(subject.failure_file).to eq '/tmp/failures/testy/CancellationDialog.diff'
     end
   end
 


### PR DESCRIPTION
Also with a .diff extension we can essentially store the diff file in the same directory as the original and have a script to use the diff as the original at some point.