### PR TITLE
Migrate to image magick compare

### DIFF
--- a/lib/dotdiff.rb
+++ b/lib/dotdiff.rb
@@ -18,7 +18,7 @@ module DotDiff
       :image_store_path, :overwrite_on_resave, :xpath_elements_to_hide,
       :max_wait_time
 
-    attr_writer :image_magick_options
+    attr_writer :image_magick_options, :pixel_threshold
 
     def configure
       yield self
@@ -34,6 +34,10 @@ module DotDiff
 
     def image_magick_options
       @image_magick_options ||= '-fuzz 5% -metric AE'
+    end
+
+    def pixel_threshold
+      @pixel_threshold ||= 100
     end
 
     def max_wait_time

--- a/lib/dotdiff.rb
+++ b/lib/dotdiff.rb
@@ -14,11 +14,11 @@ require 'dotdiff/comparer'
 
 module DotDiff
   class << self
-    attr_accessor :image_magick_diff_bin, :resave_base_image, :failure_image_path,
+    attr_accessor :resave_base_image, :failure_image_path,
       :image_store_path, :overwrite_on_resave, :xpath_elements_to_hide,
       :max_wait_time
 
-    attr_writer :image_magick_options, :pixel_threshold
+    attr_writer :image_magick_options, :pixel_threshold, :image_magick_diff_bin
 
     def configure
       yield self
@@ -34,6 +34,10 @@ module DotDiff
 
     def image_magick_options
       @image_magick_options ||= '-fuzz 5% -metric AE'
+    end
+
+    def image_magick_diff_bin
+      @image_magick_diff_bin.to_s.strip
     end
 
     def pixel_threshold

--- a/lib/dotdiff.rb
+++ b/lib/dotdiff.rb
@@ -14,7 +14,7 @@ require 'dotdiff/comparer'
 
 module DotDiff
   class << self
-    attr_accessor :perceptual_diff_bin, :resave_base_image, :failure_image_path,
+    attr_accessor :image_magick_diff_bin, :resave_base_image, :failure_image_path,
       :image_store_path, :overwrite_on_resave, :xpath_elements_to_hide,
       :max_wait_time
 

--- a/lib/dotdiff.rb
+++ b/lib/dotdiff.rb
@@ -13,22 +13,28 @@ require 'dotdiff/snapshot'
 require 'dotdiff/comparer'
 
 module DotDiff
- class << self
-   attr_accessor :perceptual_diff_bin, :resave_base_image, :failure_image_path,
-                 :image_store_path, :overwrite_on_resave, :xpath_elements_to_hide,
-                 :max_wait_time
+  class << self
+    attr_accessor :perceptual_diff_bin, :resave_base_image, :failure_image_path,
+      :image_store_path, :overwrite_on_resave, :xpath_elements_to_hide,
+      :max_wait_time
 
-   def configure
-     yield self
-   end
+    attr_writer :image_magick_options
 
-   def resave_base_image
-     @resave_base_image ||= false
-   end
+    def configure
+      yield self
+    end
 
-   def xpath_elements_to_hide
-     @xpath_elements_to_hide ||= []
-   end
+    def resave_base_image
+      @resave_base_image ||= false
+    end
+
+    def xpath_elements_to_hide
+      @xpath_elements_to_hide ||= []
+    end
+
+    def image_magick_options
+      @image_magick_options ||= '-fuzz 5% -metric AE'
+    end
 
     def max_wait_time
       @max_wait_time || Capybara.default_max_wait_time

--- a/lib/dotdiff/command_wrapper.rb
+++ b/lib/dotdiff/command_wrapper.rb
@@ -4,8 +4,8 @@ module DotDiff
   class CommandWrapper
     attr_reader :message
 
-    def run(base_image, new_image)
-      output = run_command(base_image, new_image)
+    def run(base_image, new_image, diff_image_path)
+      output = run_command(base_image, new_image, diff_image_path)
 
       @ran_checks = true
 
@@ -39,13 +39,14 @@ module DotDiff
     private
 
     # For the tests
-    def run_command(base_image, new_image)
-      `#{command(base_image, new_image)}`.strip
+    def run_command(base_image, new_image, diff_image_path)
+      `#{command(base_image, new_image, diff_image_path)}`.strip
     end
 
-    def command(base_image, new_image)
+    def command(base_image, new_image, diff_image_path)
       "#{DotDiff.image_magick_diff_bin} #{DotDiff.image_magick_options} " \
-      "#{Shellwords.escape(base_image)} #{Shellwords.escape(new_image)} /dev/null 2>&1"
+      "#{Shellwords.escape(base_image)} #{Shellwords.escape(new_image)} " \
+      "#{Shellwords.escape(diff_image_path)} 2>&1"
     end
   end
 end

--- a/lib/dotdiff/comparer.rb
+++ b/lib/dotdiff/comparer.rb
@@ -45,7 +45,7 @@ module DotDiff
 
     def compare(compare_to_image)
       result = CommandWrapper.new
-      result.run(snapshot.basefile, compare_to_image)
+      result.run(snapshot.basefile, compare_to_image, snapshot.diff_file)
 
       if result.failed? && DotDiff.failure_image_path
         FileUtils.mkdir_p(snapshot.failure_path)

--- a/lib/dotdiff/comparer.rb
+++ b/lib/dotdiff/comparer.rb
@@ -49,7 +49,7 @@ module DotDiff
 
       if result.failed? && DotDiff.failure_image_path
         FileUtils.mkdir_p(snapshot.failure_path)
-        FileUtils.mv(compare_to_image, snapshot.failure_file, force: true)
+        FileUtils.mv(compare_to_image, snapshot.new_file, force: true)
       end
 
       [result.passed?, result.message]

--- a/lib/dotdiff/snapshot.rb
+++ b/lib/dotdiff/snapshot.rb
@@ -43,7 +43,7 @@ module DotDiff
     end
 
     def failure_path
-      File.join(DotDiff.failure_image_path, subdir)
+      File.join(DotDiff.failure_image_path.to_s, subdir)
     end
 
     def new_file

--- a/lib/dotdiff/snapshot.rb
+++ b/lib/dotdiff/snapshot.rb
@@ -46,8 +46,12 @@ module DotDiff
       File.join(DotDiff.failure_image_path, subdir)
     end
 
-    def failure_file
+    def new_file
       File.join(failure_path, "#{base_filename(false)}.new.#{IMAGE_EXT}" )
+    end
+
+    def diff_file
+      File.join(failure_path, "#{base_filename(false)}.diff.#{IMAGE_EXT}")
     end
 
     def capture_from_browser(hide_and_show = true, element_handler = ElementHandler.new(page))

--- a/lib/dotdiff/snapshot.rb
+++ b/lib/dotdiff/snapshot.rb
@@ -2,7 +2,7 @@ module DotDiff
   class Snapshot
     include Image::Cropper
 
-    attr_reader :base_filename, :subdir, :rootdir, :page
+    attr_reader :base_filename, :subdir, :rootdir, :page, :use_custom_screenshot
 
     IMAGE_EXT = 'png'.freeze
 
@@ -12,6 +12,8 @@ module DotDiff
       @subdir = opts[:subdir].to_s
       @rootdir = opts[:rootdir].to_s
       @page = opts[:page]
+      @fullscreen = opts[:fullscreen_file]
+      @use_custom_screenshot = opts[:use_custom_screenshot]
     end
 
     def fullscreen_file
@@ -49,6 +51,8 @@ module DotDiff
     end
 
     def capture_from_browser(hide_and_show = true, element_handler = ElementHandler.new(page))
+      return fullscreen_file if use_custom_screenshot
+
       if hide_and_show
         element_handler.hide
         page.save_screenshot(fullscreen_file)

--- a/spec/unit/command_wrapper_spec.rb
+++ b/spec/unit/command_wrapper_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe DotDiff::CommandWrapper do
   describe '#command' do
     let(:base_img) { '/home/test/image 12343.png' }
     let(:new_img)  { '/home/test/img_1234 3.png' }
-    let(:escaped_cmd) { "/bin/compare -fuzz 5% /home/test/image\\ 12343.png /home/test/img_1234\\ 3.png /dev/null 2>&1" }
+    let(:diff_img) { '/img/test 1.diff.png' }
+    let(:escaped_cmd) { "/bin/compare -fuzz 5% /home/test/image\\ 12343.png /home/test/img_1234\\ 3.png /img/test\\ 1.diff.png 2>&1" }
 
     it 'escapes both base and new file names and contains the additional options' do
-      expect(subject.send(:command, base_img, new_img)).to eq escaped_cmd
+      expect(subject.send(:command, base_img, new_img, diff_img)).to eq escaped_cmd
     end
   end
 
@@ -25,7 +26,7 @@ RSpec.describe DotDiff::CommandWrapper do
       it 'returns failed as false when it is under the threshold' do
         allow(subject).to receive(:run_command).and_return('97.0')
 
-        subject.run('image_1', 'image_2')
+        subject.run('image_1', 'image_2', 'diff_image')
         expect(subject.failed?).to be_falsey
         expect(subject.message).to be_nil
       end
@@ -33,14 +34,14 @@ RSpec.describe DotDiff::CommandWrapper do
       it 'returns failed as false when it is equal to the threshold' do
         allow(subject).to receive(:run_command).and_return('98.23')
 
-        subject.run('image_1', 'image_2')
+        subject.run('image_1', 'image_2', 'diff_image')
         expect(subject.failed?).to be_falsey
         expect(subject.message).to be_nil
       end
 
       it 'returns failed as true with pixel diff message' do
         allow(subject).to receive(:run_command).and_return('98.43')
-        subject.run('image_1', 'image_2')
+        subject.run('image_1', 'image_2', 'diff_image')
 
         expect(subject.failed?).to be_truthy
         expect(subject.message).to eq 'Images are 98.43 pixels different'
@@ -52,7 +53,7 @@ RSpec.describe DotDiff::CommandWrapper do
 
       before do
         allow(subject).to receive(:run_command).and_return(error)
-        subject.run("image_1", "image_2")
+        subject.run('image_1', 'image_2', 'diff_image')
       end
 
       it 'assigns true to failed when return stdout is not a float' do
@@ -66,7 +67,7 @@ RSpec.describe DotDiff::CommandWrapper do
 
       it 'raises an exception when program not found' do
         allow(subject).to receive(:run_command).and_return(error)
-        subject.run('image_1','image_2')
+        subject.run('image_1', 'image_2', 'diff_image')
 
         expect(subject.failed?).to be_truthy
         expect(subject.message).to eq error

--- a/spec/unit/command_wrapper_spec.rb
+++ b/spec/unit/command_wrapper_spec.rb
@@ -2,40 +2,74 @@ require 'spec_helper'
 
 RSpec.describe DotDiff::CommandWrapper do
   subject { DotDiff::CommandWrapper.new }
-  before  { DotDiff.perceptual_diff_bin = '/bin/echo' }
 
-  let(:base_img) { '/home/test/image 12343.png' }
-  let(:new_img)  { '/home/test/compare_1234 3.png' }
+  before do
+    DotDiff.image_magick_diff_bin = '/bin/compare'
+    DotDiff.image_magick_options = '-fuzz 5%'
+  end
 
   describe '#command' do
-    let(:escaped_cmd) { "/bin/echo /home/test/image\\ 12343.png /home/test/compare_1234\\ 3.png -verbose" }
+    let(:base_img) { '/home/test/image 12343.png' }
+    let(:new_img)  { '/home/test/img_1234 3.png' }
+    let(:escaped_cmd) { "/bin/compare -fuzz 5% /home/test/image\\ 12343.png /home/test/img_1234\\ 3.png /dev/null 2>&1" }
 
-    it 'escapes both base and new file names' do
+    it 'escapes both base and new file names and contains the additional options' do
       expect(subject.send(:command, base_img, new_img)).to eq escaped_cmd
     end
   end
 
   describe '#run' do
-      it 'assigns false to failed variable' do
-        subject.run('PASS: They are the same', '')
-        expect(subject.failed?).to eq false
+    before { DotDiff.pixel_threshold = 98.23 }
+
+    context 'when it returns a number' do
+      it 'returns failed as false when it is under the threshold' do
+        allow(subject).to receive(:run_command).and_return('97.0')
+
+        subject.run('image_1', 'image_2')
+        expect(subject.failed?).to be_falsey
+        expect(subject.message).to be_nil
       end
 
-    context 'when it fails' do
-      before { subject.run('FAIL:', "haha\ngood") }
+      it 'returns failed as false when it is equal to the threshold' do
+        allow(subject).to receive(:run_command).and_return('98.23')
 
-      it 'assigns true to failed when stdout has FAIL' do
+        subject.run('image_1', 'image_2')
+        expect(subject.failed?).to be_falsey
+        expect(subject.message).to be_nil
+      end
+
+      it 'returns failed as true with pixel diff message' do
+        allow(subject).to receive(:run_command).and_return('98.43')
+        subject.run('image_1', 'image_2')
+
         expect(subject.failed?).to be_truthy
-        expect(subject.message).to eq "FAIL: haha good -verbose"
+        expect(subject.message).to eq 'Images are 98.43 pixels different'
+      end
+    end
+
+    context "when it doesn't return a number" do
+      let(:error) { "compare: Image width/height do not match" }
+
+      before do
+        allow(subject).to receive(:run_command).and_return(error)
+        subject.run("image_1", "image_2")
+      end
+
+      it 'assigns true to failed when return stdout is not a float' do
+        expect(subject.failed?).to be_truthy
+        expect(subject.message).to eq error
       end
     end
 
     context 'when the program doesnt exist' do
-      before  { DotDiff.perceptual_diff_bin = '/bin/echoo' }
-      let(:error) { "No such file or directory - /bin/echoo" }
+      let(:error) { "No such file or directory - /bin/compare" }
 
       it 'raises an exception when program not found' do
-        expect { subject.run('haha','haha') }.to raise_error(Errno::ENOENT, error)
+        allow(subject).to receive(:run_command).and_return(error)
+        subject.run('image_1','image_2')
+
+        expect(subject.failed?).to be_truthy
+        expect(subject.message).to eq error
       end
     end
   end

--- a/spec/unit/comparer_spec.rb
+++ b/spec/unit/comparer_spec.rb
@@ -113,9 +113,11 @@ RSpec.describe DotDiff::Comparer do
       end
 
       context 'when images match' do
+        before { allow(DotDiff).to receive(:failure_image_path).and_return(nil) }
+
         it 'calls command wrapper' do
           expect_any_instance_of(DotDiff::CommandWrapper).to receive(:run)
-           .with('/home/se/images/test.png', '/tmp/new.png').once
+            .with('/home/se/images/test.png', '/tmp/new.png', '/images/test.diff.png').once
 
           expect(FileUtils).to receive(:mv).exactly(0).times
           expect(subject.send(:compare, '/tmp/new.png')).to eq [true, nil]
@@ -123,6 +125,8 @@ RSpec.describe DotDiff::Comparer do
       end
 
       context 'when the images dont match' do
+        let(:diff_file) { '/tmp/fails/images/test.diff.png' }
+
         before do
           command_wrapper.instance_variable_set('@ran_checks', true)
           command_wrapper.instance_variable_set('@failed', true)
@@ -133,7 +137,7 @@ RSpec.describe DotDiff::Comparer do
 
         it 'returns false' do
           expect_any_instance_of(DotDiff::CommandWrapper).to receive(:run)
-            .with('/home/se/images/test.png', '/tmp/new.png').once
+            .with('/home/se/images/test.png', '/tmp/new.png', diff_file).once
 
           expect(FileUtils).to receive(:mkdir_p).with('/tmp/fails/images').once
           expect(FileUtils).to receive(:mv)

--- a/spec/unit/dotdiff_config_spec.rb
+++ b/spec/unit/dotdiff_config_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe 'Dotdiff configuration' do
     end
   end
 
+  describe 'pixel_threshold' do
+    it 'returns the default 100 pixels' do
+      expect(subject.pixel_threshold).to eq 100
+    end
+
+    it 'returns the user defined value' do
+      DotDiff.pixel_threshold = 120
+      expect(subject.pixel_threshold).to eq 120
+    end
+  end
+
   describe '#image_store_path' do
     let(:path) { '/tmp/image_store_path' }
 

--- a/spec/unit/dotdiff_config_spec.rb
+++ b/spec/unit/dotdiff_config_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe 'Dotdiff configuration' do
     end
   end
 
+  describe '#image_magick_options' do
+    let(:opts) { '-fuzz 10% -metric phash' }
+
+    it 'returns the default options' do
+      expect(subject.image_magick_options).to eq '-fuzz 5% -metric AE'
+    end
+
+    it 'returns the user set options' do
+      DotDiff.image_magick_options = opts
+      expect(subject.image_magick_options).to eq opts
+    end
+  end
+
   describe '#image_store_path' do
     let(:path) { '/tmp/image_store_path' }
 

--- a/spec/unit/dotdiff_config_spec.rb
+++ b/spec/unit/dotdiff_config_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe 'Dotdiff configuration' do
     end
   end
 
+  describe '#image_magick_diff_bin' do
+    it 'trims any newlines' do
+      DotDiff.image_magick_diff_bin = "/usr/bin/compare\n"
+      expect(DotDiff.image_magick_diff_bin).to eq '/usr/bin/compare'
+    end
+  end
+
   describe '#image_magick_options' do
     let(:opts) { '-fuzz 10% -metric phash' }
 

--- a/spec/unit/snapshot_spec.rb
+++ b/spec/unit/snapshot_spec.rb
@@ -63,9 +63,15 @@ RSpec.describe DotDiff::Snapshot do
     end
   end
 
-  describe '#failure_file' do
+  describe '#new_file' do
+    it 'returns the failure_path and filename with new extension' do
+      expect(subject.new_file).to eq '/tmp/failures/testy/CancellationDialog.new.png'
+    end
+  end
+
+  describe '#diff_file' do
     it 'returns the failure_path and filename with diff extension' do
-      expect(subject.failure_file).to eq '/tmp/failures/testy/CancellationDialog.new.png'
+      expect(subject.diff_file).to eq '/tmp/failures/testy/CancellationDialog.diff.png'
     end
   end
 

--- a/spec/unit/snapshot_spec.rb
+++ b/spec/unit/snapshot_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe DotDiff::Snapshot do
-  let(:options) {{ filename: 'CancellationDialog', subdir: 'testy', page: MockPage.new }}
+  let(:options) {{
+    filename: 'CancellationDialog',
+    subdir: 'testy',
+    page: MockPage.new
+  }}
+
   subject { DotDiff::Snapshot.new(options) }
 
   before do
@@ -11,10 +16,16 @@ RSpec.describe DotDiff::Snapshot do
   end
 
   describe '#initialize' do
+    let(:opts) { options.merge(fullscreen_file: '/somedir', use_custom_screenshot: true) }
+
+    subject { DotDiff::Snapshot.new(opts) }
+
     it 'initializes base_filename, subdir and rootdir' do
       expect(subject.base_filename).to eq 'CancellationDialog.png'
       expect(subject.subdir).to eq 'testy'
       expect(subject.rootdir).to eq '/home/se/images'
+      expect(subject.fullscreen_file).to eq '/somedir'
+      expect(subject.use_custom_screenshot).to be_truthy
     end
   end
 
@@ -63,6 +74,16 @@ RSpec.describe DotDiff::Snapshot do
       expect(subject).to receive(:fullscreen_file).and_return('/tmp/T/basefile.png').once
       expect(subject.page).to receive(:save_screenshot).with('/tmp/T/basefile.png').once
       subject.capture_from_browser
+    end
+
+    context 'use_custom_screenshot is true' do
+      let(:opts) { options.merge(fullscreen_file: '/somedir/file.png', use_custom_screenshot: true) }
+      subject { DotDiff::Snapshot.new(opts) }
+
+      it 'returns fullscreen_file path when use_custom_screenshot is true' do
+        expect(subject.page).to receive(:save_screenshot).with('/tmp/T/basefile.png').exactly(0).times
+        expect(subject.capture_from_browser).to eq '/somedir/file.png'
+      end
     end
   end
 


### PR DESCRIPTION
The reason for the change is due to the fact that perceptual diff is a third slower than image magick phash metric. 

Perceptual - ~3 seconds
Compare -metric phash ~1 second

However we are able to also get even faster by utilising the Absolute Error metric with a 5% fuzz returning the pixel difference which comes in at around ~0.25s so having to screenshot 480 elements reduces the time dramatically.

This also allows you to pass down a custom fullscreen image file path which can then be used instead of it snapshotting the full page for every element that is on a static page.