### PR TITLE
Add JRuby support via rmagick4j

### DIFF
--- a/dotdiff.gemspec
+++ b/dotdiff.gemspec
@@ -20,7 +20,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rmagick", '~> 2.15'
+  if RUBY_PLATFORM == 'java'
+    spec.add_runtime_dependency "rmagick4j", '~> 0.4.0'
+  else
+    spec.add_runtime_dependency "rmagick", '~> 2.15'
+  end
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
`rmagick4j`'s API is the same as the native version, so no other changes were needed to the code. The tests are passing when run with `jruby -S rake` (after a `jruby -S bundle`).

Fixes https://github.com/jnormington/dotdiff/issues/15