### PR TITLE
Add spec.platform to .gemspec if on JRuby

### DIFF
--- a/dotdiff.gemspec
+++ b/dotdiff.gemspec
@@ -3,11 +3,14 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'dotdiff/version'
 
+is_java = RUBY_PLATFORM == 'java'
+
 Gem::Specification.new do |spec|
   spec.name          = "dotdiff"
   spec.version       = DotDiff::VERSION
   spec.authors       = ["Jon Normington"]
   spec.email         = ["jnormington@users.noreply.github.com"]
+  spec.platform      = 'java' if is_java
 
   spec.summary       = "Preceptual diff wrapper for capybara and rspec image regression specs"
   spec.description   = [spec.summary, "which is great for graphs and charts where checking"\
@@ -20,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  if RUBY_PLATFORM == 'java'
+  if is_java
     spec.add_runtime_dependency "rmagick4j", '~> 0.4.0'
   else
     spec.add_runtime_dependency "rmagick", '~> 2.15'


### PR DESCRIPTION
Thanks for merging the other pull-request!

Of course, it doesn't work simply like that, because of these:

https://github.com/phatworx/easy_captcha/issues/30
https://github.com/rubygems/rubygems/issues/1662#issuecomment-232067212

I couldn't have caught this as this doesn't happen during development, only after a gem is released.

In short - this means that you have to build a `Java` specific version of the gem because the `.gemspec` file is evaluated only at gem-build-time. You're building it (I guess) with `gem build dotdiff` which builds it with a `RUBY_PLATFORM` which is *not* `java` and that's it - the gem will then require `rmagick` and not `rmagick4j`. I read in a bunch of places and the easiest way to "fix" this is to create a java-specific gem.

With this pull-request, doing a `gem build dotdiff` does what it did before (i.e. it outputs a `dotdiff-2.0.1.gem` file) but doing a `jruby -S gem build dotdiff` outputs a `dotdiff-2.0.1-java.gem` file. Unfortunately I'm unfamiliar with publishing gems so you'll have to test this - I'm not sure whether the gem also has to have a different name (something like: `spec.name = "dotdiff" + (is_java ? '-java' : '')`) or the fact that `-java` is automatically added to the version number is enough.

Thanks!