### PR TITLE
feat: Add support for percentage threshold config

### DIFF
--- a/lib/dotdiff.rb
+++ b/lib/dotdiff.rb
@@ -12,13 +12,25 @@ require 'dotdiff/element_handler'
 require 'dotdiff/element_meta'
 require 'dotdiff/image/cropper'
 require 'dotdiff/snapshot'
+
+require 'dotdiff/threshold_calculator'
+
+require 'dotdiff/comparible/base'
+require 'dotdiff/comparible/page_comparer'
+require 'dotdiff/comparible/element_comparer'
+
 require 'dotdiff/comparer'
 
 module DotDiff
+  class UnknownTypeError < StandardError; end
+  class InvalidValueError < StandardError; end
+
+  SUPPORTED_THRESHOLD_TYPES = %w[pixel percent].freeze
+
   class << self
     attr_accessor :failure_image_path, :image_store_path, :overwrite_on_resave
 
-    attr_writer :image_magick_options, :pixel_threshold, :image_magick_diff_bin,
+    attr_writer :image_magick_options, :image_magick_diff_bin,
                 :resave_base_image, :xpath_elements_to_hide, :hide_elements_on_non_full_screen_screenshot
 
     def configure
@@ -46,7 +58,25 @@ module DotDiff
     end
 
     def pixel_threshold
-      @pixel_threshold ||= 100
+      @pixel_threshold ||= { type: 'pixel', value: 100 }
+    end
+
+    def pixel_threshold=(config)
+      unless config.class == Hash
+        Kernel.warn '[Dotdiff deprecation] Pass a hash options instead of integer to support pixel/percentage threshold'
+        @pixel_threshold = config
+        return
+      end
+
+      unless SUPPORTED_THRESHOLD_TYPES.include?(config.fetch(:type))
+        raise UnknownTypeError, "Unknown threshold type supports only: #{SUPPORTED_THRESHOLD_TYPES.join(',')}"
+      end
+
+      if config.fetch(:type) == 'percent' && config.fetch(:value) > 1
+        raise InvalidValueError, 'Percent value should be a float between 0 and 1'
+      end
+
+      @pixel_threshold = config
     end
   end
 end

--- a/lib/dotdiff/command_wrapper.rb
+++ b/lib/dotdiff/command_wrapper.rb
@@ -4,25 +4,17 @@ require 'shellwords'
 
 module DotDiff
   class CommandWrapper
-    attr_reader :message, :ran_checks
+    attr_reader :message, :pixels
 
     def run(base_image, new_image, diff_image_path)
       output = run_command(base_image, new_image, diff_image_path)
-
-      @ran_checks = true
+      @message = output
 
       begin
-        pixels = Float(output)
-
-        if pixels && pixels <= DotDiff.pixel_threshold
-          @failed = false
-        else
-          @failed = true
-          @message = "Images are #{pixels} pixels different"
-        end
+        @pixels = Float(output)
+        @failed = false
       rescue ArgumentError
         @failed = true
-        @message = output
       end
     end
 
@@ -31,12 +23,11 @@ module DotDiff
     end
 
     def failed?
-      @ran_checks && @failed
+      @failed
     end
 
     private
 
-    # For the tests
     def run_command(base_image, new_image, diff_image_path)
       `#{command(base_image, new_image, diff_image_path)}`.strip
     end

--- a/lib/dotdiff/comparer.rb
+++ b/lib/dotdiff/comparer.rb
@@ -12,49 +12,12 @@ module DotDiff
 
     def result
       if element.is_a?(Capybara::Session)
-        compare_page
+        DotDiff::Comparible::PageComparer.run(snapshot, nil)
       elsif element.is_a?(Capybara::Node::Base)
-        compare_element
+        DotDiff::Comparible::ElementComparer.run(snapshot, ElementMeta.new(page, element))
       else
         raise ArgumentError, "Unknown element class received: #{element.class.name}"
       end
-    end
-
-    private
-
-    def compare_element(element_meta = ElementMeta.new(page, element))
-      snapshot.capture_from_browser(DotDiff.hide_elements_on_non_full_screen_screenshot)
-      snapshot.crop_and_resave(element_meta)
-
-      if !File.exist?(snapshot.basefile)
-        snapshot.resave_cropped_file
-        [true, snapshot.basefile]
-      else
-        compare(snapshot.cropped_file)
-      end
-    end
-
-    def compare_page
-      snapshot.capture_from_browser(true)
-
-      if !File.exist?(snapshot.basefile)
-        snapshot.resave_fullscreen_file
-        [true, snapshot.basefile]
-      else
-        compare(snapshot.fullscreen_file)
-      end
-    end
-
-    def compare(compare_to_image)
-      result = CommandWrapper.new
-      result.run(snapshot.basefile, compare_to_image, snapshot.diff_file)
-
-      if result.failed? && DotDiff.failure_image_path
-        FileUtils.mkdir_p(snapshot.failure_path)
-        FileUtils.mv(compare_to_image, snapshot.new_file, force: true)
-      end
-
-      [result.passed?, result.message]
     end
   end
 end

--- a/lib/dotdiff/comparible/base.rb
+++ b/lib/dotdiff/comparible/base.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module DotDiff
+  module Comparible
+    class Base
+      def initialize(snapshot, element_meta)
+        @snapshot = snapshot
+        @element_meta = element_meta
+      end
+
+      def self.run(snapshot, element_meta)
+        new(snapshot, element_meta).run
+      end
+
+      private
+
+      attr_reader :snapshot, :element_meta
+
+      def compare(compare_to_image)
+        cmd = CommandWrapper.new
+        cmd.run(snapshot.basefile, compare_to_image, snapshot.diff_file)
+
+        return [cmd.passed?, cmd.message] if cmd.failed?
+
+        calc = calculator(cmd.pixels)
+        passed = calc.under_threshold?
+        write_failure_imgs(compare_to_image) if !passed && DotDiff.failure_image_path
+
+        [passed, calc.message]
+      end
+
+      def calculator(diff_pixels)
+        DotDiff::ThresholdCalculator.new(
+          DotDiff.pixel_threshold,
+          basefile_pixels,
+          diff_pixels
+        )
+      end
+
+      def basefile_pixels
+        img = Magick::Image.read(snapshot.basefile).first
+        img.rows * img.columns
+      end
+
+      def write_failure_imgs(compare_to_image)
+        FileUtils.mkdir_p(snapshot.failure_path)
+        FileUtils.mv(compare_to_image, snapshot.new_file, force: true)
+      end
+    end
+  end
+end

--- a/lib/dotdiff/comparible/element_comparer.rb
+++ b/lib/dotdiff/comparible/element_comparer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module DotDiff
+  module Comparible
+    class ElementComparer < Base
+      def run
+        take_snapshot_and_crop
+
+        if !File.exist?(snapshot.basefile)
+          snapshot.resave_cropped_file
+          [true, snapshot.basefile]
+        else
+          compare(snapshot.cropped_file)
+        end
+      end
+
+      private
+
+      def take_snapshot_and_crop
+        snapshot.capture_from_browser(DotDiff.hide_elements_on_non_full_screen_screenshot)
+        snapshot.crop_and_resave(element_meta)
+      end
+    end
+  end
+end

--- a/lib/dotdiff/comparible/page_comparer.rb
+++ b/lib/dotdiff/comparible/page_comparer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module DotDiff
+  module Comparible
+    class PageComparer < Base
+      def run
+        snapshot.capture_from_browser(true)
+
+        if !File.exist?(snapshot.basefile)
+          snapshot.resave_fullscreen_file
+          [true, snapshot.basefile]
+        else
+          compare(snapshot.fullscreen_file)
+        end
+      end
+    end
+  end
+end

--- a/lib/dotdiff/threshold_calculator.rb
+++ b/lib/dotdiff/threshold_calculator.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module DotDiff
+  class ThresholdCalculator
+    class UnknownTypeError < StandardError; end
+
+    PIXEL = 'pixel'
+    PERCENT = 'percent'
+
+    def initialize(threshold_config, total_pixels, pixel_diff)
+      @threshold_config = threshold_config
+      @total_pixels = total_pixels
+      @pixel_diff = pixel_diff
+    end
+
+    def under_threshold?
+      return false if total_pixels.nil? || pixel_diff.nil?
+
+      case threshold_type
+      when PIXEL
+        @value = pixel_diff
+      when PERCENT
+        @value = pixel_diff / total_pixels.to_f
+      else
+        raise UnknownTypeError, "Unable to handle threshold type: #{threshold_type}"
+      end
+
+      value <= threshold_value
+    end
+
+    def message
+      "Outcome was '#{value}' difference for type '#{threshold_type}'"
+    end
+
+    private
+
+    attr_reader :threshold_config, :pixel_diff, :total_pixels, :value
+
+    def threshold_value
+      return threshold_config if threshold_config.class == Integer
+
+      threshold_config[:value]
+    end
+
+    def threshold_type
+      return PIXEL if threshold_config.class != Hash
+
+      threshold_config[:type].to_s
+    end
+  end
+end

--- a/lib/dotdiff/threshold_calculator.rb
+++ b/lib/dotdiff/threshold_calculator.rb
@@ -2,8 +2,6 @@
 
 module DotDiff
   class ThresholdCalculator
-    class UnknownTypeError < StandardError; end
-
     PIXEL = 'pixel'
     PERCENT = 'percent'
 

--- a/spec/unit/comparible/element_comparer_spec.rb
+++ b/spec/unit/comparible/element_comparer_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DotDiff::Comparible::ElementComparer do
+  let(:element_meta) { instance_double(DotDiff::ElementMeta) }
+  let(:snapshot) do
+    instance_double(
+      DotDiff::Snapshot, basefile: 'test', fullscreen_file: 'fullscrn_file',
+                         capture_from_browser: true, diff_file: 'diff_file',
+                         cropped_file: 'crped_file', resave_fullscreen_file: true
+    )
+  end
+
+  before do
+    expect(snapshot).to receive(:crop_and_resave).with(element_meta)
+    expect(DotDiff).to receive(:hide_elements_on_non_full_screen_screenshot).and_return(true)
+  end
+
+  describe '#run' do
+    it 'captures a screenshot from the browser' do
+      allow(snapshot).to receive(:resave_cropped_file)
+      expect(snapshot).to receive(:capture_from_browser).with(true).once
+      described_class.run(snapshot, element_meta)
+    end
+
+    it 'checks if the basefile exists' do
+      allow(snapshot).to receive(:resave_cropped_file)
+      expect(File).to receive(:exist?).with(snapshot.basefile).and_return(false)
+      described_class.run(snapshot, element_meta)
+    end
+
+    context 'when the basefile doesnt exist' do
+      subject { described_class.run(snapshot, element_meta) }
+
+      before do
+        expect(File).to receive(:exist?).with(snapshot.basefile).and_return(false)
+      end
+
+      it 'calls resave_cropped_file and returns true' do
+        expect(snapshot).to receive(:resave_cropped_file)
+        expect(subject).to eq [true, snapshot.basefile]
+      end
+    end
+
+    context 'when the basefile exists' do
+      subject { described_class.run(snapshot, element_meta) }
+
+      before do
+        expect(DotDiff::CommandWrapper).to receive(:new).and_return(command_wrapper)
+        expect(command_wrapper).to receive(:run).with('test', 'crped_file', 'diff_file').and_return(nil)
+        expect(File).to receive(:exist?).with(snapshot.basefile).and_return(true)
+      end
+
+      context 'and the command fails to return pixels' do
+        let(:command_wrapper) do
+          instance_double(DotDiff::CommandWrapper, passed?: false, failed?: true, message: 'Some failure')
+        end
+
+        it 'returns false and the error message' do
+          expect(subject).to eq [false, 'Some failure']
+        end
+      end
+
+      context 'and the command succeeds' do
+        let(:command_wrapper) do
+          instance_double(DotDiff::CommandWrapper,
+                          pixels: 3210.0, passed?: true, failed?: false, message: '3210')
+        end
+
+        let(:rmagick_image) { instance_double(Magick::Image, rows: 1920, columns: 1080) }
+        let(:calc) { instance_double(DotDiff::ThresholdCalculator) }
+
+        before do
+          expect(Magick::Image).to receive(:read).with('test').and_return([rmagick_image])
+          expect(DotDiff).to receive(:pixel_threshold).and_return(100)
+          expect(DotDiff::ThresholdCalculator).to receive(:new).with(100, 2_073_600, 3210.0).and_return(calc)
+        end
+
+        context 'when calc under threshold' do
+          let(:calc) do
+            instance_double(DotDiff::ThresholdCalculator, value: 0.154, message: 'Some msg', under_threshold?: true)
+          end
+
+          it 'returns true' do
+            expect(subject).to eq [true, 'Some msg']
+          end
+        end
+
+        context 'when calc over threshold' do
+          let(:calc) do
+            instance_double(DotDiff::ThresholdCalculator, value: 0.154, message: 'Some msg', under_threshold?: false)
+          end
+
+          it 'returns true' do
+            expect(subject).to eq [false, 'Some msg']
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/comparible/page_comparer_spec.rb
+++ b/spec/unit/comparible/page_comparer_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DotDiff::Comparible::PageComparer do
+  let(:snapshot) do
+    instance_double(
+      DotDiff::Snapshot, basefile: 'test', fullscreen_file: 'fullscrn_file',
+                         capture_from_browser: true, diff_file: 'diff_file',
+                         resave_fullscreen_file: true
+    )
+  end
+
+  describe '#run' do
+    it 'captures a screenshot from the browser' do
+      expect(snapshot).to receive(:capture_from_browser).with(true).once
+      described_class.run(snapshot, nil)
+    end
+
+    it 'checks if the basefile exists' do
+      expect(File).to receive(:exist?).with(snapshot.basefile).and_return(false)
+      described_class.run(snapshot, nil)
+    end
+
+    context 'when the basefile doesnt exist' do
+      subject { described_class.run(snapshot, nil) }
+
+      it 'returns true' do
+        expect(File).to receive(:exist?).with(snapshot.basefile).and_return(false)
+        expect(subject).to eq [true, snapshot.basefile]
+      end
+    end
+
+    context 'when the basefile exists' do
+      subject { described_class.run(snapshot, nil) }
+
+      before do
+        expect(DotDiff::CommandWrapper).to receive(:new).and_return(command_wrapper)
+        expect(command_wrapper).to receive(:run).with('test', 'fullscrn_file', 'diff_file').and_return(nil)
+        expect(File).to receive(:exist?).with(snapshot.basefile).and_return(true)
+      end
+
+      context 'and the command fails to return pixels' do
+        let(:command_wrapper) do
+          instance_double(DotDiff::CommandWrapper, passed?: false, failed?: true, message: 'Some failure')
+        end
+
+        it 'returns false and the error message' do
+          expect(subject).to eq [false, 'Some failure']
+        end
+      end
+
+      context 'and the command succeeds' do
+        let(:magick_image) { instance_double(Magick::Image, rows: 1920, columns: 1080) }
+        let(:command_wrapper) do
+          instance_double(DotDiff::CommandWrapper, pixels: 321.0, passed?: true, failed?: false, message: '321')
+        end
+
+        before do
+          expect(Magick::Image).to receive(:read).with('test').and_return([magick_image])
+        end
+
+        context 'when pixels under threshold' do
+          let(:calc) do
+            instance_double(DotDiff::ThresholdCalculator, message: 'Some msg', under_threshold?: true)
+          end
+
+          before do
+            expect(DotDiff).to receive(:pixel_threshold).and_return(322)
+            expect(DotDiff::ThresholdCalculator).to receive(:new).with(322, 2_073_600, 321.0).and_return(calc)
+          end
+
+          it 'returns true' do
+            expect(subject).to eq [true, 'Some msg']
+          end
+        end
+
+        context 'when pixels over threshold' do
+          let(:calc) do
+            instance_double(DotDiff::ThresholdCalculator, message: 'Some msg', under_threshold?: false)
+          end
+
+          before do
+            expect(DotDiff).to receive(:pixel_threshold).and_return(320)
+            expect(DotDiff::ThresholdCalculator).to receive(:new).with(320, 2_073_600, 321.0).and_return(calc)
+          end
+
+          it 'returns false' do
+            expect(subject).to eq [false, 'Some msg']
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/dotdiff_config_spec.rb
+++ b/spec/unit/dotdiff_config_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe 'Dotdiff configuration' do
   describe '#image_magick_options' do
     let(:opts) { '-fuzz 10% -metric phash' }
 
+    after { DotDiff.image_magick_options = nil }
+
     it 'returns the default options' do
       expect(subject.image_magick_options).to eq '-fuzz 5% -metric AE'
     end
@@ -46,6 +48,8 @@ RSpec.describe 'Dotdiff configuration' do
   end
 
   describe 'pixel_threshold' do
+    after { DotDiff.pixel_threshold = nil }
+
     it 'returns the default 100 pixels' do
       expect(subject.pixel_threshold).to eq 100
     end
@@ -59,6 +63,8 @@ RSpec.describe 'Dotdiff configuration' do
   describe '#image_store_path' do
     let(:path) { '/tmp/image_store_path' }
 
+    after { DotDiff.image_store_path = nil }
+
     it 'returns the user set value' do
       DotDiff.image_store_path = path
       expect(subject.image_store_path).to eq path
@@ -67,6 +73,8 @@ RSpec.describe 'Dotdiff configuration' do
 
   describe '#failure_image_path' do
     let(:path) { '/tmp/failed_image_store' }
+
+    after { DotDiff.failure_image_path = nil }
 
     it 'returns the user set value' do
       DotDiff.failure_image_path = path

--- a/spec/unit/dotdiff_config_spec.rb
+++ b/spec/unit/dotdiff_config_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Dotdiff configuration' do
     after { DotDiff.pixel_threshold = nil }
 
     it 'returns the default 100 pixels' do
-      expect(subject.pixel_threshold).to eq 100
+      expect(subject.pixel_threshold).to eq({ type: 'pixel', value: 100 })
     end
 
     it 'returns the user defined value' do
@@ -91,6 +91,70 @@ RSpec.describe 'Dotdiff configuration' do
     it 'returns the user elements' do
       DotDiff.xpath_elements_to_hide = elems
       expect(subject.xpath_elements_to_hide).to eq elems
+    end
+  end
+
+  describe '#pixel_threshold' do
+    after { DotDiff.pixel_threshold = nil }
+
+    context 'when value not a hash' do
+      it 'raises a deprecation warning' do
+        expect(Kernel).to receive(:warn).with(
+          '[Dotdiff deprecation] Pass a hash options instead of integer to support pixel/percentage threshold'
+        ).twice
+
+        DotDiff.pixel_threshold = 120
+      end
+
+      it 'sets the value' do
+        DotDiff.pixel_threshold = 120
+        expect(DotDiff.pixel_threshold).to eq 120
+      end
+    end
+
+    context 'when type is pixel' do
+      let(:config) { DotDiff.pixel_threshold = { type: 'pixel', value: 120 } }
+
+      it 'sets the config value' do
+        DotDiff.pixel_threshold = config
+        expect(DotDiff.pixel_threshold).to eq config
+      end
+    end
+
+    context 'when type is percent' do
+      let(:config) { DotDiff.pixel_threshold = { type: 'percent', value: 0.9999 } }
+
+      it 'sets the config value' do
+        DotDiff.pixel_threshold = config
+        expect(DotDiff.pixel_threshold).to eq config
+      end
+    end
+
+    context 'when type is percent' do
+      let(:config) { DotDiff.pixel_threshold = { type: 'percent', value: 1 } }
+
+      it 'sets the config value' do
+        DotDiff.pixel_threshold = config
+        expect(DotDiff.pixel_threshold).to eq config
+      end
+    end
+
+    context 'when type is percent and value over 1' do
+      let(:config) { DotDiff.pixel_threshold = { type: 'percent', value: 1.01 } }
+
+      it 'raises an error' do
+        expect do
+          DotDiff.pixel_threshold = config
+        end.to raise_error DotDiff::InvalidValueError, 'Percent value should be a float between 0 and 1'
+      end
+    end
+
+    context 'when value not an invalid option' do
+      it 'raises an exception' do
+        expect do
+          DotDiff.pixel_threshold = { type: 'decimal', value: 120 }
+        end.to raise_error(DotDiff::UnknownTypeError)
+      end
     end
   end
 end

--- a/spec/unit/threshold_calculator_spec.rb
+++ b/spec/unit/threshold_calculator_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe DotDiff::ThresholdCalculator do
       subject { described_class.new({ type: 'decimal', value: 100 }, 1, 1) }
 
       it 'raises an error' do
-        expect { subject.under_threshold? }.to raise_error(DotDiff::ThresholdCalculator::UnknownTypeError)
+        expect { subject.under_threshold? }.to raise_error(DotDiff::UnknownTypeError)
       end
     end
   end

--- a/spec/unit/threshold_calculator_spec.rb
+++ b/spec/unit/threshold_calculator_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DotDiff::ThresholdCalculator do
+  describe '#under_threshold?' do
+    context 'when existing pixel config' do
+      it 'returns true' do
+        expect(described_class.new(100, 1, 99).under_threshold?).to eq true
+      end
+
+      it 'returns false' do
+        expect(described_class.new(100, 1, 101).under_threshold?).to eq false
+      end
+    end
+
+    context 'when new pixel config' do
+      it 'returns true' do
+        expect(described_class.new({ type: 'pixel', value: 100 }, 1, 99).under_threshold?).to eq true
+      end
+
+      it 'returns false' do
+        expect(described_class.new({ type: 'pixel', value: 100 }, 1, 101).under_threshold?).to eq false
+      end
+    end
+
+    context 'when percent config' do
+      it 'returns true' do
+        expect(described_class.new({ type: 'percent', value: 0.333 }, 1000, 300).under_threshold?).to eq true
+      end
+
+      it 'returns false' do
+        expect(described_class.new({ type: 'percent', value: 0.333 }, 1000, 334).under_threshold?).to eq false
+      end
+    end
+
+    context 'when unknown config' do
+      subject { described_class.new({ type: 'decimal', value: 100 }, 1, 1) }
+
+      it 'raises an error' do
+        expect { subject.under_threshold? }.to raise_error(DotDiff::ThresholdCalculator::UnknownTypeError)
+      end
+    end
+  end
+
+  describe '#message' do
+    subject { described_class.new({ type: 'percent', value: 100 }, 999, 99) }
+
+    before { subject.under_threshold? }
+
+    it 'returns the calculated value and threshold type' do
+      expect(subject.message).to eq "Outcome was '0.0990990990990991' difference for type 'percent'"
+    end
+  end
+end


### PR DESCRIPTION
- Refactors the comparer class to call out to two new classes for handling the comparison
- Adds a new ThresholdCalculator class to calculate if its under the threshold, based on the pixel_threshold config
- Adds deprecation warning about the use of integer only config
- Adds validation against the pixel_threshold config to ensure valid config
- Simplifiers the command wrapper to be just that, a class for executing the command and to return the result of the command
- Adds a new config option to support percent threshold on the comparision and diffing


There will be a followup feature to validate the base image and new image file match the same size, because it seems that the newer version of compare now don't error when the image is of very different sizes, meaning that with the new percent config option there are cases that it will incorrectly pass because the base image maybe have more pixels that the new image causing it to be under the threshold percentage incorrectly. This will be an enhancement in a new upcoming PR before a new release is created.


This PR was created in relation to the issue https://github.com/jnormington/dotdiff/issues/23