### PR TITLE
feat: Validate base and new image dimensions same

### DIFF
--- a/lib/dotdiff.rb
+++ b/lib/dotdiff.rb
@@ -11,6 +11,7 @@ require 'dotdiff/element_handler'
 
 require 'dotdiff/element_meta'
 require 'dotdiff/image/cropper'
+require 'dotdiff/image/container'
 require 'dotdiff/snapshot'
 
 require 'dotdiff/threshold_calculator'

--- a/lib/dotdiff/image/container.rb
+++ b/lib/dotdiff/image/container.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module DotDiff
+  module Image
+    class Container
+      def initialize(baseimg_file, newimg_file)
+        @baseimg_file = baseimg_file
+        @newimg_file = newimg_file
+      end
+
+      def both_images_same_dimensions?
+        base_image.rows == new_image.rows &&
+          base_image.columns == new_image.columns
+      end
+
+      def total_pixels
+        base_image.rows * base_image.columns
+      end
+
+      def dimensions_mismatch_msg
+        <<~MSG
+          Images are not the same dimensions to be compared
+          Base file: #{base_image.columns}x#{base_image.rows}
+          New file:  #{new_image.columns}x#{new_image.rows}
+        MSG
+      end
+
+      private
+
+      attr_reader :baseimg_file, :newimg_file
+
+      def base_image
+        @base_image ||= Magick::Image.read(baseimg_file).first
+      end
+
+      def new_image
+        @new_image ||= Magick::Image.read(newimg_file).first
+      end
+    end
+  end
+end

--- a/spec/unit/image/container_spec.rb
+++ b/spec/unit/image/container_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DotDiff::Image::Container do
+  let(:baseimg_file) { 'baseimg_file.png' }
+  let(:newimg_file) { 'newimg_file.png' }
+
+  subject { described_class.new(baseimg_file, newimg_file) }
+
+  describe '#both_image_same_dimensions' do
+    before do
+      expect(Magick::Image).to receive(:read).with(baseimg_file).and_return([base_img])
+      expect(Magick::Image).to receive(:read).with(newimg_file).and_return([new_img])
+    end
+
+    context 'when both rows and columns match' do
+      let(:base_img) { instance_double(Magick::Image, rows: 100, columns: 120) }
+      let(:new_img) { instance_double(Magick::Image, rows: 100, columns: 120) }
+
+      it 'returns true' do
+        expect(subject.both_images_same_dimensions?).to eq true
+      end
+    end
+
+    context 'when the rows are mismatch' do
+      let(:base_img) { instance_double(Magick::Image, rows: 101, columns: 120) }
+      let(:new_img) { instance_double(Magick::Image, rows: 100, columns: 120) }
+
+      it 'returns false' do
+        expect(subject.both_images_same_dimensions?).to eq false
+      end
+    end
+
+    context 'when the rows are mismatch' do
+      let(:base_img) { instance_double(Magick::Image, rows: 100, columns: 120) }
+      let(:new_img) { instance_double(Magick::Image, rows: 100, columns: 121) }
+
+      it 'returns false' do
+        expect(subject.both_images_same_dimensions?).to eq false
+      end
+    end
+  end
+
+  describe '#total_pixels' do
+    let(:base_img) { instance_double(Magick::Image, rows: 1280, columns: 764) }
+
+    before do
+      expect(Magick::Image).to receive(:read).with(baseimg_file).and_return([base_img])
+    end
+
+    it 'returns the total pixels' do
+      expect(subject.total_pixels).to eq 977_920
+    end
+  end
+
+  describe '#dimensions_mismatch_msg' do
+    let(:base_img) { instance_double(Magick::Image, rows: 100, columns: 120) }
+    let(:new_img) { instance_double(Magick::Image, rows: 100, columns: 121) }
+
+    before do
+      expect(Magick::Image).to receive(:read).with(baseimg_file).and_return([base_img])
+      expect(Magick::Image).to receive(:read).with(newimg_file).and_return([new_img])
+    end
+
+    it 'returns a message with the dimensions' do
+      expect(subject.dimensions_mismatch_msg).to eq(
+        <<~MSG
+          Images are not the same dimensions to be compared
+          Base file: 120x100
+          New file:  121x100
+        MSG
+      )
+    end
+  end
+end


### PR DESCRIPTION
Before we even shell out to compare them. We need to validate if the images we are comparing are of the same dimension, it used to be that compare would error or mismatch dimensions. With newer versions this appears to be no longer the case.

So we need to introduce this image container to validate that both images are of equal dimensions before comparing.

This is expecially important for percentage threshold config because the base image may have more pixels that the new image
causing it to incorrectly pass when it should infact fail

Its the followup PR to https://github.com/jnormington/dotdiff/pull/24 - to fully support percentage threshold for issue https://github.com/jnormington/dotdiff/issues/23