### PR TITLE
fix: Ensure to write new images on dimension mismatch

### DIFF
--- a/lib/dotdiff/comparer.rb
+++ b/lib/dotdiff/comparer.rb
@@ -11,12 +11,30 @@ module DotDiff
     end
 
     def result
-      if element.is_a?(Capybara::Session)
-        DotDiff::Comparible::PageComparer.run(snapshot, nil)
-      elsif element.is_a?(Capybara::Node::Base)
-        DotDiff::Comparible::ElementComparer.run(snapshot, ElementMeta.new(page, element))
-      else
+      comparer = build_comparer
+
+      if comparer.nil?
         raise ArgumentError, "Unknown element class received: #{element.class.name}"
+      end
+
+      passed, msg = comparer.run
+      write_failure_imgs(comparer.new_image_path) if !passed && DotDiff.failure_image_path
+
+      [passed, msg]
+    end
+
+    private
+
+    def write_failure_imgs(new_image_path)
+      FileUtils.mkdir_p(snapshot.failure_path)
+      FileUtils.mv(new_image_path, snapshot.new_file, force: true)
+    end
+
+    def build_comparer
+      if element.is_a?(Capybara::Session)
+        DotDiff::Comparible::PageComparer.new(snapshot, nil)
+      elsif element.is_a?(Capybara::Node::Base)
+        DotDiff::Comparible::ElementComparer.new(snapshot, ElementMeta.new(page, element))
       end
     end
   end

--- a/lib/dotdiff/comparible/base.rb
+++ b/lib/dotdiff/comparible/base.rb
@@ -14,14 +14,13 @@ module DotDiff
 
       private
 
-      attr_reader :snapshot, :element_meta, :new_image
+      attr_reader :snapshot, :element_meta
 
       def compare(compare_to_image)
-        @new_image = compare_to_image
         return [false, img_container.dimensions_mismatch_msg] unless img_container.both_images_same_dimensions?
 
         cmd = CommandWrapper.new
-        cmd.run(snapshot.basefile, new_image, snapshot.diff_file)
+        cmd.run(snapshot.basefile, new_image_path, snapshot.diff_file)
         return [cmd.passed?, cmd.message] if cmd.failed?
 
         calculate_result(cmd.pixels)
@@ -34,22 +33,14 @@ module DotDiff
           diff_pixels
         )
 
-        passed = calc.under_threshold?
-        write_failure_imgs if !passed && DotDiff.failure_image_path
-
-        [passed, calc.message]
+        [calc.under_threshold?, calc.message]
       end
 
       def img_container
         @img_container ||= DotDiff::Image::Container.new(
           snapshot.basefile,
-          new_image
+          new_image_path
         )
-      end
-
-      def write_failure_imgs
-        FileUtils.mkdir_p(snapshot.failure_path)
-        FileUtils.mv(new_image, snapshot.new_file, force: true)
       end
     end
   end

--- a/lib/dotdiff/comparible/element_comparer.rb
+++ b/lib/dotdiff/comparible/element_comparer.rb
@@ -14,6 +14,10 @@ module DotDiff
         end
       end
 
+      def new_image_path
+        snapshot.cropped_file
+      end
+
       private
 
       def take_snapshot_and_crop

--- a/lib/dotdiff/comparible/page_comparer.rb
+++ b/lib/dotdiff/comparible/page_comparer.rb
@@ -13,6 +13,10 @@ module DotDiff
           compare(snapshot.fullscreen_file)
         end
       end
+
+      def new_image_path
+        snapshot.fullscreen_file
+      end
     end
   end
 end

--- a/spec/unit/comparer_spec.rb
+++ b/spec/unit/comparer_spec.rb
@@ -22,25 +22,89 @@ RSpec.describe DotDiff::Comparer do
 
   describe '#outcome' do
     context 'when element Capybara::Session' do
-      it 'calls page comparer' do
-        expect(element).to receive(:is_a?).with(Capybara::Session).and_return(true)
-        expect(DotDiff::Comparible::PageComparer).to receive(:run).with(snapshot, nil).once
+      let(:comparer) { instance_double(DotDiff::Comparible::PageComparer)  }
 
-        subject.result
+      before do
+        expect(element).to receive(:is_a?).with(Capybara::Session).and_return(true)
+        expect(DotDiff::Comparible::PageComparer).to receive(:new)
+          .with(snapshot, nil).and_return(comparer)
+      end
+
+      it 'calls page comparer' do
+        expect(comparer).to receive(:run).and_return([true, ''])
+        expect(subject.result).to eq([true, ''])
+      end
+
+      context 'when comparer result is false' do
+        before do
+          expect(comparer).to receive(:run).and_return([false, 'some failure'])
+
+          allow(DotDiff).to receive(:failure_image_path).and_return('fake_path')
+        end
+
+        it 'resaves the new_image to .new' do
+          expect(comparer).to receive(:new_image_path).and_return('fullscrn_path')
+          expect(FileUtils).to receive(:mkdir_p).with('fake_path/images')
+          expect(FileUtils).to receive(:mv).with('fullscrn_path', 'fake_path/images/test.new.png', force: true)
+
+          expect(subject.result).to eq([false, 'some failure'])
+        end
+
+        context 'when no failure path set' do
+          before do
+            allow(DotDiff).to receive(:failure_image_path).and_return(nil)
+          end
+
+          it 'doesnt resave any file' do
+            expect(FileUtils).not_to receive(:mkdir_p)
+            expect(FileUtils).not_to receive(:mv)
+            expect(subject.result).to eq([false, 'some failure'])
+          end
+        end
       end
     end
 
     context 'when element Capybara::Node::Base' do
+      let(:comparer) { instance_double(DotDiff::Comparible::ElementComparer)  }
       let(:element_meta) { DotDiff::ElementMeta.new(page, element) }
 
-      it 'calls element comparer' do
+      before do
         expect(element).to receive(:is_a?).with(Capybara::Session).and_return(false)
         expect(element).to receive(:is_a?).with(Capybara::Node::Base).and_return(true)
 
         expect(DotDiff::ElementMeta).to receive(:new).with(page, element).and_return(element_meta)
-        expect(DotDiff::Comparible::ElementComparer).to receive(:run).with(snapshot, element_meta).once
+        expect(DotDiff::Comparible::ElementComparer).to receive(:new)
+          .with(snapshot, element_meta).and_return(comparer)
+      end
 
-        subject.result
+      it 'calls element comparer' do
+        expect(comparer).to receive(:run).and_return([true, ''])
+        expect(subject.result).to eq([true, ''])
+      end
+
+      context 'when comparer result is false' do
+        before do
+          expect(comparer).to receive(:run).and_return([false, 'some failure'])
+          allow(DotDiff).to receive(:failure_image_path).and_return('fake_path')
+        end
+
+        it 'resaves the new_image to .new' do
+          expect(comparer).to receive(:new_image_path).and_return('fullscrn_path')
+          expect(FileUtils).to receive(:mkdir_p).with('fake_path/images')
+          expect(FileUtils).to receive(:mv).with('fullscrn_path', 'fake_path/images/test.new.png', force: true)
+
+          expect(subject.result).to eq([false, 'some failure'])
+        end
+
+        context 'when no failure path set' do
+          before { allow(DotDiff).to receive(:failure_image_path).and_return(nil) }
+
+          it 'doesnt resave any file' do
+            expect(FileUtils).not_to receive(:mkdir_p)
+            expect(FileUtils).not_to receive(:mv)
+            expect(subject.result).to eq([false, 'some failure'])
+          end
+        end
       end
     end
 

--- a/spec/unit/comparible/element_comparer_spec.rb
+++ b/spec/unit/comparible/element_comparer_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe DotDiff::Comparible::ElementComparer do
     )
   end
 
-  before do
-    expect(snapshot).to receive(:crop_and_resave).with(element_meta)
-    expect(DotDiff).to receive(:hide_elements_on_non_full_screen_screenshot).and_return(true)
-  end
-
   describe '#run' do
+    before do
+      expect(snapshot).to receive(:crop_and_resave).with(element_meta)
+      expect(DotDiff).to receive(:hide_elements_on_non_full_screen_screenshot).and_return(true)
+    end
+
     it 'captures a screenshot from the browser' do
       allow(snapshot).to receive(:resave_cropped_file)
       expect(snapshot).to receive(:capture_from_browser).with(true).once
@@ -121,6 +121,14 @@ RSpec.describe DotDiff::Comparible::ElementComparer do
           end
         end
       end
+    end
+  end
+
+  describe '#new_image_path' do
+    subject { described_class.new(snapshot, element_meta) }
+
+    it 'returns cropped file path' do
+      expect(subject.new_image_path).to eq 'crped_file'
     end
   end
 end

--- a/spec/unit/comparible/page_comparer_spec.rb
+++ b/spec/unit/comparible/page_comparer_spec.rb
@@ -114,4 +114,12 @@ RSpec.describe DotDiff::Comparible::PageComparer do
       end
     end
   end
+
+  describe '#new_image_path' do
+    subject { described_class.new(snapshot, nil) }
+
+    it 'returns cropped file path' do
+      expect(subject.new_image_path).to eq 'fullscrn_file'
+    end
+  end
 end


### PR DESCRIPTION
Now that we need to check for image resolution mismatches, we now check this before comparing the images. However with that change we would now no longer create the relevant `.new` image files.

This PR moves the writing of the new screenshots to the .new failure path into the comparer instead of under the comparible module. This allows any false result returned from any compariable class to then allow the comparer class to write failed images. 