### PR TITLE
Use `mini_magick` instead of `rmagick`

### DIFF
--- a/dotdiff.gemspec
+++ b/dotdiff.gemspec
@@ -4,14 +4,11 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'dotdiff/version'
 
-is_java = RUBY_PLATFORM == 'java'
-
 Gem::Specification.new do |spec|
   spec.name          = 'dotdiff'
   spec.version       = DotDiff::VERSION
   spec.authors       = ['Jon Normington']
   spec.email         = ['jnormington@users.noreply.github.com']
-  spec.platform      = 'java' if is_java
 
   spec.summary       = 'Image regression wrapper for Capybara and RSpec using image'\
                         'magick supporting both MRI and JRuby versions'
@@ -25,11 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  if is_java
-    spec.add_runtime_dependency 'rmagick4j', '>= 0.4.0'
-  else
-    spec.add_runtime_dependency 'rmagick', '>= 2.15'
-  end
+  spec.add_runtime_dependency 'mini_magick', '>= 4.11.0'
 
   spec.add_development_dependency 'bundler', '>= 2'
   spec.add_development_dependency 'capybara', '>= 2.6'

--- a/lib/dotdiff/image/container.rb
+++ b/lib/dotdiff/image/container.rb
@@ -9,19 +9,19 @@ module DotDiff
       end
 
       def both_images_same_dimensions?
-        base_image.rows == new_image.rows &&
-          base_image.columns == new_image.columns
+        base_image.width == new_image.width &&
+          base_image.height == new_image.height
       end
 
       def total_pixels
-        base_image.rows * base_image.columns
+        base_image.width * base_image.height
       end
 
       def dimensions_mismatch_msg
         <<~MSG
           Images are not the same dimensions to be compared
-          Base file: #{base_image.columns}x#{base_image.rows}
-          New file:  #{new_image.columns}x#{new_image.rows}
+          Base file: #{base_image.width}x#{base_image.height}
+          New file:  #{new_image.width}x#{new_image.height}
         MSG
       end
 
@@ -30,11 +30,11 @@ module DotDiff
       attr_reader :baseimg_file, :newimg_file
 
       def base_image
-        @base_image ||= Magick::Image.read(baseimg_file).first
+        @base_image ||= MiniMagick::Image.open(baseimg_file)
       end
 
       def new_image
-        @new_image ||= Magick::Image.read(newimg_file).first
+        @new_image ||= MiniMagick::Image.open(newimg_file)
       end
     end
   end

--- a/lib/dotdiff/image/cropper.rb
+++ b/lib/dotdiff/image/cropper.rb
@@ -1,29 +1,31 @@
 # frozen_string_literal: true
 
-require 'rmagick'
+require 'mini_magick'
 
 module DotDiff
   module Image
     module Cropper
       def crop_and_resave(element)
         image = load_image(fullscreen_file)
-        image.crop!(
-          element.rectangle.x.floor,
-          element.rectangle.y.floor,
-          width(element, image),
-          height(element, image)
-        )
 
+        # @see http://www.imagemagick.org/script/command-line-options.php?#crop
+        crop_area =
+          '' + width(element, image).to_s +
+          'x' + height(element, image).to_s +
+          '+' + element.rectangle.x.floor.to_s +
+          '+' + element.rectangle.y.floor.to_s
+
+        image.crop crop_area
         image.write(cropped_file)
       end
 
       def load_image(file)
-        Magick::Image.read(file).first
+        MiniMagick::Image.open(file)
       end
 
       def height(element, image)
         element_height = element.rectangle.height + element.rectangle.y
-        image_height = image.rows
+        image_height = image.height
 
         if element_height > image_height
           image_height - element.rectangle.y
@@ -34,7 +36,7 @@ module DotDiff
 
       def width(element, image)
         element_width = element.rectangle.width + element.rectangle.x
-        image_width = image.columns
+        image_width = image.width
 
         if element_width > image_width
           image_width - element.rectangle.x

--- a/spec/unit/image/container_spec.rb
+++ b/spec/unit/image/container_spec.rb
@@ -10,31 +10,31 @@ RSpec.describe DotDiff::Image::Container do
 
   describe '#both_image_same_dimensions' do
     before do
-      expect(Magick::Image).to receive(:read).with(baseimg_file).and_return([base_img])
-      expect(Magick::Image).to receive(:read).with(newimg_file).and_return([new_img])
+      expect(MiniMagick::Image).to receive(:open).with(baseimg_file).and_return(base_img)
+      expect(MiniMagick::Image).to receive(:open).with(newimg_file).and_return(new_img)
     end
 
-    context 'when both rows and columns match' do
-      let(:base_img) { instance_double(Magick::Image, rows: 100, columns: 120) }
-      let(:new_img) { instance_double(Magick::Image, rows: 100, columns: 120) }
+    context 'when both width and height match' do
+      let(:base_img) { instance_double(MiniMagick::Image, width: 120, height: 100) }
+      let(:new_img) { instance_double(MiniMagick::Image, width: 120, height: 100) }
 
       it 'returns true' do
         expect(subject.both_images_same_dimensions?).to eq true
       end
     end
 
-    context 'when the rows are mismatch' do
-      let(:base_img) { instance_double(Magick::Image, rows: 101, columns: 120) }
-      let(:new_img) { instance_double(Magick::Image, rows: 100, columns: 120) }
+    context 'when the height are mismatch' do
+      let(:base_img) { instance_double(MiniMagick::Image, width: 120, height: 101) }
+      let(:new_img) { instance_double(MiniMagick::Image, width: 120, height: 100) }
 
       it 'returns false' do
         expect(subject.both_images_same_dimensions?).to eq false
       end
     end
 
-    context 'when the rows are mismatch' do
-      let(:base_img) { instance_double(Magick::Image, rows: 100, columns: 120) }
-      let(:new_img) { instance_double(Magick::Image, rows: 100, columns: 121) }
+    context 'when the height are mismatch' do
+      let(:base_img) { instance_double(MiniMagick::Image, width: 120, height: 100) }
+      let(:new_img) { instance_double(MiniMagick::Image, width: 121, height: 100) }
 
       it 'returns false' do
         expect(subject.both_images_same_dimensions?).to eq false
@@ -43,10 +43,10 @@ RSpec.describe DotDiff::Image::Container do
   end
 
   describe '#total_pixels' do
-    let(:base_img) { instance_double(Magick::Image, rows: 1280, columns: 764) }
+    let(:base_img) { instance_double(MiniMagick::Image, width: 764, height: 1280) }
 
     before do
-      expect(Magick::Image).to receive(:read).with(baseimg_file).and_return([base_img])
+      expect(MiniMagick::Image).to receive(:open).with(baseimg_file).and_return(base_img)
     end
 
     it 'returns the total pixels' do
@@ -55,12 +55,12 @@ RSpec.describe DotDiff::Image::Container do
   end
 
   describe '#dimensions_mismatch_msg' do
-    let(:base_img) { instance_double(Magick::Image, rows: 100, columns: 120) }
-    let(:new_img) { instance_double(Magick::Image, rows: 100, columns: 121) }
+    let(:base_img) { instance_double(MiniMagick::Image, width: 120, height: 100) }
+    let(:new_img) { instance_double(MiniMagick::Image, width: 121, height: 100) }
 
     before do
-      expect(Magick::Image).to receive(:read).with(baseimg_file).and_return([base_img])
-      expect(Magick::Image).to receive(:read).with(newimg_file).and_return([new_img])
+      expect(MiniMagick::Image).to receive(:open).with(baseimg_file).and_return(base_img)
+      expect(MiniMagick::Image).to receive(:open).with(newimg_file).and_return(new_img)
     end
 
     it 'returns a message with the dimensions' do

--- a/spec/unit/image/cropper_spec.rb
+++ b/spec/unit/image/cropper_spec.rb
@@ -14,25 +14,25 @@ class Snappy
   end
 end
 
-class MockRMagick
-  def crop!(xxx, yyy, www, hhh); end
+class MockMiniMagick
+  def crop(format); end
 
   def write(file); end
 
-  def columns; end
+  def width; end
 
-  def rows; end
+  def height; end
 end
 
 RSpec.describe DotDiff::Image::Cropper do
   subject { Snappy.new }
 
   let(:element) { DotDiff::ElementMeta.new(MockPage.new, MockElement.new) }
-  let(:mock_png) { MockRMagick.new }
+  let(:mock_png) { MockMiniMagick.new }
 
   describe '#load_image' do
-    it 'calls rgmagick image read' do
-      expect(Magick::Image).to receive(:read).with('/home/se/full.png').once.and_return([])
+    it 'calls minimagick image open' do
+      expect(MiniMagick::Image).to receive(:open).with('/home/se/full.png').once.and_return(nil)
       subject.send(:load_image, '/home/se/full.png')
     end
   end
@@ -47,7 +47,7 @@ RSpec.describe DotDiff::Image::Cropper do
       expect(subject).to receive(:width).with(element, mock_png).and_return(13).once
       expect(subject).to receive(:height).with(element, mock_png).and_return(14).once
 
-      expect(mock_png).to receive(:crop!).with(1, 2, 13, 14).once
+      expect(mock_png).to receive(:crop).with("13x14+1+2").once
       expect(mock_png).to receive(:write).with('/tmp/T/cropped.png').once
     end
 
@@ -75,7 +75,7 @@ RSpec.describe DotDiff::Image::Cropper do
       let(:rect) { { 'top' => -180, 'left' => 0, 'width' => 800, 'height' => 1400 } }
 
       it 'returns the image height minus the top point' do
-        allow(mock_png).to receive(:rows).and_return(1200)
+        allow(mock_png).to receive(:height).and_return(1200)
         expect(subject.height(element, mock_png)).to eq 1380
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe DotDiff::Image::Cropper do
       let(:rect) { { 'top' => -180, 'left' => 0, 'width' => 500, 'height' => 800 } }
 
       it 'returns the element height' do
-        allow(mock_png).to receive(:rows).and_return(1200)
+        allow(mock_png).to receive(:height).and_return(1200)
         expect(subject.height(element, mock_png)).to eq 800
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe DotDiff::Image::Cropper do
       let(:rect) { { 'top' => -180, 'left' => -30, 'width' => 731, 'height' => 1200 } }
 
       it 'returns the image width minus the left point' do
-        allow(mock_png).to receive(:columns).and_return(700)
+        allow(mock_png).to receive(:width).and_return(700)
         expect(subject.width(element, mock_png)).to eq 730
       end
     end
@@ -106,7 +106,7 @@ RSpec.describe DotDiff::Image::Cropper do
       let(:rect) { { 'top' => -180, 'left' => -20, 'width' => 800, 'height' => 800 } }
 
       it 'returns the element width' do
-        allow(mock_png).to receive(:columns).and_return(850)
+        allow(mock_png).to receive(:width).and_return(850)
         expect(subject.width(element, mock_png)).to eq 800
       end
     end


### PR DESCRIPTION
The former works fine on both Ruby and JRuby while the latter supports
only Ruby. Even with the JRuby-specific version (`rmagick4j`) it still
doesn't work on JRuby 9.4.0.0+ because it requires Ruby version < 3

cc @jnormington 

I just tried my project with JRuby 9.4.0.0 and I couldn't install my gems because RMagick4J requires Ruby < 3 but that version of JRuby is Ruby 3.1.0.

I haven't **actually** tried these changes. Not sure how to do that. Any suggestions? Pretty much the only thing I'm unsure about is [this](https://github.com/jnormington/dotdiff/compare/master...boris-petrov:minimagick?expand=1#diff-78c53e4e69a61451c3d39867fc25bb1cc3e4b12204f141f39f5dc2bc535c51f6R11) - as you see, `mini_magick` requires some string which I'm not sure what the argument-order is (and I can't seem to find it in their documentation).